### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/kibana.js
+++ b/kibana.js
@@ -1,3 +1,5 @@
+const {Service, Container, publicInternet} = require("@quilt/quilt");
+
 function Kibana(es) {
     this.service = new Service("kibana", [
         new Container("kibana:4",

--- a/main.js
+++ b/main.js
@@ -1,5 +1,6 @@
-var Elasticsearch = require("github.com/quilt/elasticsearch").Elasticsearch;
-var Kibana = require("github.com/quilt/kibana").Kibana;
+const {createDeployment, Machine} = require("@quilt/quilt");
+var Elasticsearch = require("@quilt/elasticsearch").Elasticsearch;
+var Kibana = require("./kibana.js").Kibana;
 
 var clusterSize = 2;
 

--- a/package.json
+++ b/package.json
@@ -1,3 +1,10 @@
 {
-    "main": "./kibana.js"
+  "name": "@quilt/kibana",
+  "version": "0.0.1",
+  "main": "./kibana.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt",
+    "@quilt/elasticsearch": "quilt/elasticsearch"
+  }
 }


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.